### PR TITLE
Changement nom license

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"url": "git+https://github.com/TanguyChiffoleau/Le-bot-en-JS.git"
 	},
 	"author": "Tanguy Chiffoleau",
-	"license": "MIT License",
+	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/TanguyChiffoleau/Le-bot-en-JS/issues"
 	},


### PR DESCRIPTION
Utilisation de l'identifiant SPDX plutôt que le nom pour éviter le warn d'npm