### PR TITLE
Developpement

### DIFF
--- a/src/commands/misc/infos.js
+++ b/src/commands/misc/infos.js
@@ -14,9 +14,6 @@ module.exports = {
 			embed: {
 				color: '01579B',
 				title: 'Infos',
-				author: {
-					name: client.user.username,
-				},
 				fields: [
 					{
 						name: 'Latence API',

--- a/src/commands/misc/vote.js
+++ b/src/commands/misc/vote.js
@@ -14,6 +14,7 @@ module.exports = {
 	requirePermissions: [],
 	execute: async (client, message, args) => {
 		// Suppression du message
+		client.cache.deleteMessagesID.add(message.id)
 		message.delete()
 
 		// Envoie du message de vote

--- a/src/util/loaders.js
+++ b/src/util/loaders.js
@@ -39,8 +39,9 @@ module.exports = {
 			return client
 		},
 
-		// Connecte le client en utilisant le token
-		login: client => client.login(process.env.DISCORD_TOKEN),
+		// Connecte le client en utilisant la
+		// variable d'environnement DISCORD_TOKEN
+		login: client => client.login(),
 	},
 
 	// Chargement des commandes


### PR DESCRIPTION
- Suppression du nom du bot dans la commande infos
- Suppression variable env DISCORD_TOKEN pour login car Discord.js utilise par défaut process.env.DISCORD_TOKEN pour le token de connexion pour le client
- Fix: ajout du message supprimé dans le cache pour éviter le log du message supprimé par le bot