### PR TITLE
Fix : string.match() peut renvoyer null dans la fonction getMember()

### DIFF
--- a/src/commands/misc/whois.js
+++ b/src/commands/misc/whois.js
@@ -4,6 +4,8 @@ const getMember = (message, mentionOrID) => {
 	if (!mentionOrID) return message.member
 
 	const matches = mentionOrID.match(/^<@!?(\d{17,19})>$|^(\d{17,19})$/)
+	if (!matches) return
+
 	const targetID = matches[1] || matches[2]
 	return message.guild.members.cache.get(targetID)
 }


### PR DESCRIPTION
Ajout d'un early return pour éviter d'utiliser une propriété indéfinie générant une erreur